### PR TITLE
Add support for Amazon Bedrock models

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ datasets>=2.14.6
 diskcache>=5.6.3
 graphviz>=0.20.3
 gdown>=5.2.0
+boto3>=1.34.133

--- a/textgrad/engine/__init__.py
+++ b/textgrad/engine/__init__.py
@@ -22,6 +22,11 @@ def get_engine(engine_name: str, **kwargs) -> EngineLM:
     if (("gpt-4" in engine_name) or ("gpt-3.5" in engine_name)):
         from .openai import ChatOpenAI
         return ChatOpenAI(model_string=engine_name, **kwargs)
+    # bedrock incluedes most of the models so first check
+    elif "bedrock" in engine_name:
+        from .bedrock import ChatBedrock
+        engine_name = engine_name.replace("bedrock-", "")
+        return ChatBedrock(model_string=engine_name, **kwargs)
     elif "claude" in engine_name:
         from .anthropic import ChatAnthropic
         return ChatAnthropic(model_string=engine_name, **kwargs)
@@ -35,9 +40,5 @@ def get_engine(engine_name: str, **kwargs) -> EngineLM:
     elif engine_name in ["command-r-plus", "command-r", "command", "command-light"]:
         from .cohere import ChatCohere
         return ChatCohere(model_string=engine_name, **kwargs)
-    elif "bedrock" in engine_name:
-        from .bedrock import ChatBedrock
-        engine_name = engine_name.replace("bedrock-", "")
-        return ChatBedrock(model_string=engine_name, **kwargs)
     else:
         raise ValueError(f"Engine {engine_name} not supported")

--- a/textgrad/engine/__init__.py
+++ b/textgrad/engine/__init__.py
@@ -17,7 +17,7 @@ def get_engine(engine_name: str, **kwargs) -> EngineLM:
     if (("gpt-4" in engine_name) or ("gpt-3.5" in engine_name)):
         from .openai import ChatOpenAI
         return ChatOpenAI(model_string=engine_name, **kwargs)
-    # bedrock incluedes most of the models so first check
+    # bedrock incluedes most of the models so first check if the request is for it
     elif "bedrock" in engine_name:
         from .bedrock import ChatBedrock
         engine_name = engine_name.replace("bedrock-", "")

--- a/textgrad/engine/__init__.py
+++ b/textgrad/engine/__init__.py
@@ -4,12 +4,7 @@ __ENGINE_NAME_SHORTCUTS__ = {
     "opus": "claude-3-opus-20240229",
     "haiku": "claude-3-haiku-20240307",
     "sonnet": "claude-3-sonnet-20240229",
-    "together-llama-3-70b": "together-meta-llama/Llama-3-70b-chat-hf",
-    "bedrock-sonnet-3": "bedrock-anthropic.claude-3-sonnet-20240229-v1:0",
-    "bedrock-sonnet-3.5": "bedrock-anthropic.claude-3-5-sonnet-20240620-v1:0",
-    "bedrock-opus": "bedrock-anthropic.claude-3-opus-20240229-v1:0",
-    "bedrock-haiku": "bedrock-anthropic.claude-3-haiku-20240307-v1:0",
-    "bedrock-mistral-large": "bedrock-mistral.mistral-large-2402-v1:0"
+    "together-llama-3-70b": "together-meta-llama/Llama-3-70b-chat-hf"
 }
 
 def get_engine(engine_name: str, **kwargs) -> EngineLM:

--- a/textgrad/engine/__init__.py
+++ b/textgrad/engine/__init__.py
@@ -5,6 +5,11 @@ __ENGINE_NAME_SHORTCUTS__ = {
     "haiku": "claude-3-haiku-20240307",
     "sonnet": "claude-3-sonnet-20240229",
     "together-llama-3-70b": "together-meta-llama/Llama-3-70b-chat-hf",
+    "bedrock-sonnet-3": "bedrock-anthropic.claude-3-sonnet-20240229-v1:0",
+    "bedrock-sonnet-3.5": "bedrock-anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "bedrock-opus": "bedrock-anthropic.claude-3-opus-20240229-v1:0",
+    "bedrock-haiku": "bedrock-anthropic.claude-3-haiku-20240307-v1:0",
+    "bedrock-mistral-large": "bedrock-mistral.mistral-large-2402-v1:0"
 }
 
 def get_engine(engine_name: str, **kwargs) -> EngineLM:
@@ -30,5 +35,9 @@ def get_engine(engine_name: str, **kwargs) -> EngineLM:
     elif engine_name in ["command-r-plus", "command-r", "command", "command-light"]:
         from .cohere import ChatCohere
         return ChatCohere(model_string=engine_name, **kwargs)
+    elif "bedrock" in engine_name:
+        from .bedrock import ChatBedrock
+        engine_name = engine_name.replace("bedrock-", "")
+        return ChatBedrock(model_string=engine_name, **kwargs)
     else:
         raise ValueError(f"Engine {engine_name} not supported")

--- a/textgrad/engine/bedrock.py
+++ b/textgrad/engine/bedrock.py
@@ -84,6 +84,6 @@ class ChatBedrock(EngineLM, CachedEngine):
         
         response = self.generate_conversation(self.model_string, system_prompts=sys_prompt_args, messages=messages, temperature=temperature, top_p=top_p, max_tokens=max_tokens)
 
-        response = response.choices[0].message.content
+        response = response["output"]["message"]["content"][0]["text"]
         self._save_cache(sys_prompt_arg + prompt, response)
         return response

--- a/textgrad/engine/bedrock.py
+++ b/textgrad/engine/bedrock.py
@@ -108,13 +108,10 @@ class ChatBedrock(EngineLM, CachedEngine):
             "content": [{"text": prompt}]
             }]
         else:
-            messages = [{
-            "role": "user",
-            "content": [{"text": sys_prompt_arg}]
-            },
+            messages = [
             {
             "role": "user",
-            "content": [{"text": prompt}]
+            "content": [{"text": sys_prompt_arg + "\n\n" + prompt}]
             }]
         
         response = self.generate_conversation(self.model_string, system_prompts=sys_prompt_args, messages=messages, temperature=temperature, top_p=top_p, max_tokens=max_tokens)

--- a/textgrad/engine/bedrock.py
+++ b/textgrad/engine/bedrock.py
@@ -38,6 +38,9 @@ class ChatBedrock(EngineLM, CachedEngine):
                 self.system_prompt_supported = True
         if "amazon" in model_string:
             self.system_prompt_supported = False
+        if "ai21" in model_string:
+            self.system_prompt_supported = False
+            raise ValueError("ai21 not supported yet")
   
         self.max_tokens = kwargs.get("max_tokens", None)
         self.aws_region = kwargs.get("region", None)

--- a/textgrad/engine/bedrock.py
+++ b/textgrad/engine/bedrock.py
@@ -37,6 +37,11 @@ class ChatBedrock(EngineLM, CachedEngine):
                 self.system_prompt_supported = True
         if "amazon" in model_string:
             self.system_prompt_supported = False
+        
+        if kwargs["max_tokens"]:
+            self.max_tokens = kwargs["max_tokens"]
+        if kwargs["region"]:
+            self.aws_region = kwargs["region"]
 
         root = platformdirs.user_cache_dir("textgrad")
         cache_path = os.path.join(root, f"cache_bedrock_{model_string}.db")
@@ -66,7 +71,7 @@ class ChatBedrock(EngineLM, CachedEngine):
         """
 
         # Base inference parameters to use.
-        inference_config = {"temperature": temperature, "topP": top_p, "maxTokens": max_tokens}
+        inference_config = {"temperature": temperature, "topP": top_p, "maxTokens": self.max_tokens if self.max_tokens else max_tokens}
         if("anthropic" in model_id): 
             # Additional inference parameters to use.
             additional_model_fields = {"top_k": top_k}

--- a/textgrad/engine/bedrock.py
+++ b/textgrad/engine/bedrock.py
@@ -38,10 +38,8 @@ class ChatBedrock(EngineLM, CachedEngine):
         if "amazon" in model_string:
             self.system_prompt_supported = False
         
-        if kwargs.get("max_tokens"):
-            self.max_tokens = kwargs["max_tokens"]
-        if kwargs.get("region"):
-            self.aws_region = kwargs["region"]
+        self.max_tokens = kwargs.get("max_tokens", None)
+        self.aws_region = kwargs.get("region", None)
 
         root = platformdirs.user_cache_dir("textgrad")
         cache_path = os.path.join(root, f"cache_bedrock_{model_string}.db")

--- a/textgrad/engine/bedrock.py
+++ b/textgrad/engine/bedrock.py
@@ -38,9 +38,9 @@ class ChatBedrock(EngineLM, CachedEngine):
         if "amazon" in model_string:
             self.system_prompt_supported = False
         
-        if kwargs["max_tokens"]:
+        if kwargs.get("max_tokens"):
             self.max_tokens = kwargs["max_tokens"]
-        if kwargs["region"]:
+        if kwargs.get("region"):
             self.aws_region = kwargs["region"]
 
         root = platformdirs.user_cache_dir("textgrad")

--- a/textgrad/engine/bedrock.py
+++ b/textgrad/engine/bedrock.py
@@ -47,6 +47,7 @@ class ChatBedrock(EngineLM, CachedEngine):
         self.max_tokens = kwargs.get("max_tokens", None)
         self.aws_region = kwargs.get("region", None)
 
+        # handle both AWS interaction options: with default credential or providing AWS ACCESS KEY and SECRET KEY
         if boto3._get_default_session().get_credentials() is not None:
             if self.aws_region:
                 self.my_config = Config(region_name = self.aws_region)

--- a/textgrad/engine/bedrock.py
+++ b/textgrad/engine/bedrock.py
@@ -84,7 +84,6 @@ class ChatBedrock(EngineLM, CachedEngine):
         
         response = self.generate_conversation(self.model_string, system_prompts=sys_prompt_args, messages=messages, temperature=temperature, top_p=top_p, max_tokens=max_tokens)
 
-
-        response = response.text
+        response = response.choices[0].message.content
         self._save_cache(sys_prompt_arg + prompt, response)
         return response

--- a/textgrad/engine/bedrock.py
+++ b/textgrad/engine/bedrock.py
@@ -24,7 +24,7 @@ class ChatBedrock(EngineLM, CachedEngine):
         system_prompt=SYSTEM_PROMPT,
         **kwargs
     ):
-        
+        self.system_prompt_supported = True
         if "anthropic" in model_string:
             self.system_prompt_supported = True
         if "meta" in model_string:
@@ -38,6 +38,8 @@ class ChatBedrock(EngineLM, CachedEngine):
                 self.system_prompt_supported = True
         if "amazon" in model_string:
             self.system_prompt_supported = False
+            if "premier" in model_string:
+                raise ValueError("amazon-titan-premier not supported yet")
         if "ai21" in model_string:
             self.system_prompt_supported = False
             raise ValueError("ai21 not supported yet")

--- a/textgrad/engine/bedrock.py
+++ b/textgrad/engine/bedrock.py
@@ -37,7 +37,7 @@ class ChatBedrock(EngineLM, CachedEngine):
     def __call__(self, prompt, **kwargs):
         return self.generate(prompt, **kwargs)
     
-    def generate_conversation(self, model_id="", system_prompt="", messages=[], temperature=0.5, top_k=200, top_p=0.99, max_tokens=4096):
+    def generate_conversation(self, model_id="", system_prompts=[], messages=[], temperature=0.5, top_k=200, top_p=0.99, max_tokens=4096):
         """
         Sends messages to a model.
         Args:
@@ -52,7 +52,7 @@ class ChatBedrock(EngineLM, CachedEngine):
         """
 
         # Base inference parameters to use.
-        inference_config = {"temperature": temperature, "top_p": top_p, "maxTokens": max_tokens}
+        inference_config = {"temperature": temperature, "topP": top_p, "maxTokens": max_tokens}
         # Additional inference parameters to use.
         additional_model_fields = {"top_k": top_k}
         
@@ -60,7 +60,7 @@ class ChatBedrock(EngineLM, CachedEngine):
         response = self.client.converse(
             modelId=model_id,
             messages=messages,
-            system=system_prompt,
+            system=system_prompts,
             inferenceConfig=inference_config,
             additionalModelRequestFields=additional_model_fields
         )
@@ -72,6 +72,7 @@ class ChatBedrock(EngineLM, CachedEngine):
     ):
 
         sys_prompt_arg = system_prompt if system_prompt else self.system_prompt
+        sys_prompt_args = [{"text": sys_prompt_arg}]
         cache_or_none = self._check_cache(sys_prompt_arg + prompt)
         if cache_or_none is not None:
             return cache_or_none
@@ -81,7 +82,7 @@ class ChatBedrock(EngineLM, CachedEngine):
         "content": [{"text": prompt}]
         }]      
         
-        response = self.generate_conversation(self.model_string, system_prompt=sys_prompt_arg, messages=messages, temperature=temperature, top_p=top_p, max_tokens=max_tokens)
+        response = self.generate_conversation(self.model_string, system_prompts=sys_prompt_args, messages=messages, temperature=temperature, top_p=top_p, max_tokens=max_tokens)
 
 
         response = response.text

--- a/textgrad/engine/bedrock.py
+++ b/textgrad/engine/bedrock.py
@@ -49,7 +49,7 @@ class ChatBedrock(EngineLM, CachedEngine):
 
         if self.aws_region:
             self.my_config = Config(region_name = self.aws_region)
-            self.client = boto3.client(service_name='bedrock-runtime', config=my_config)
+            self.client = boto3.client(service_name='bedrock-runtime', config=self.my_config)
         else:
             self.client = boto3.client(service_name='bedrock-runtime')
 

--- a/textgrad/engine/bedrock.py
+++ b/textgrad/engine/bedrock.py
@@ -53,8 +53,11 @@ class ChatBedrock(EngineLM, CachedEngine):
 
         # Base inference parameters to use.
         inference_config = {"temperature": temperature, "topP": top_p, "maxTokens": max_tokens}
-        # Additional inference parameters to use.
-        additional_model_fields = {"top_k": top_k}
+        if("anthropic" in model_id): 
+            # Additional inference parameters to use.
+            additional_model_fields = {"top_k": top_k}
+        else: 
+            additional_model_fields = {}
         
         # Send the message.
         response = self.client.converse(

--- a/textgrad/engine/bedrock.py
+++ b/textgrad/engine/bedrock.py
@@ -1,0 +1,89 @@
+try:
+    import boto3
+
+except ImportError:
+    raise ImportError("If you'd like to use Amazon Bedrock models, please install the boto3 package by running `pip install boto3`")
+
+import os
+import platformdirs
+from tenacity import (
+    retry,
+    stop_after_attempt,
+    wait_random_exponential,
+)
+from .base import EngineLM, CachedEngine
+
+
+class ChatBedrock(EngineLM, CachedEngine):
+    SYSTEM_PROMPT = "You are a helpful, creative, and smart assistant."
+    
+    def __init__(
+        self,
+        model_string="anthropic.claude-3-sonnet-20240229-v1:0",
+        system_prompt=SYSTEM_PROMPT,
+        **kwargs
+    ):
+
+        root = platformdirs.user_cache_dir("textgrad")
+        cache_path = os.path.join(root, f"cache_bedrock_{model_string}.db")
+        super().__init__(cache_path=cache_path)
+        
+        self.model_string = model_string
+        self.system_prompt = system_prompt
+        self.client = boto3.client(service_name='bedrock-runtime')
+        assert isinstance(self.system_prompt, str)
+
+    @retry(wait=wait_random_exponential(min=1, max=5), stop=stop_after_attempt(5))
+    def __call__(self, prompt, **kwargs):
+        return self.generate(prompt, **kwargs)
+    
+    def generate_conversation(self, model_id="", system_prompt="", messages=[], temperature=0.5, top_k=200, top_p=0.99, max_tokens=4096):
+        """
+        Sends messages to a model.
+        Args:
+            bedrock_client: The Boto3 Bedrock runtime client.
+            model_id (str): The model ID to use.
+            system_prompts (JSON) : The system prompts for the model to use.
+            messages (JSON) : The messages to send to the model.
+
+        Returns:
+            response (JSON): The conversation that the model generated.
+
+        """
+
+        # Base inference parameters to use.
+        inference_config = {"temperature": temperature, "top_p": top_p, "maxTokens": max_tokens}
+        # Additional inference parameters to use.
+        additional_model_fields = {"top_k": top_k}
+        
+        # Send the message.
+        response = self.client.converse(
+            modelId=model_id,
+            messages=messages,
+            system=system_prompt,
+            inferenceConfig=inference_config,
+            additionalModelRequestFields=additional_model_fields
+        )
+
+        return response
+
+    def generate(
+        self, prompt, system_prompt=None, temperature=0, max_tokens=4096, top_p=0.99
+    ):
+
+        sys_prompt_arg = system_prompt if system_prompt else self.system_prompt
+        cache_or_none = self._check_cache(sys_prompt_arg + prompt)
+        if cache_or_none is not None:
+            return cache_or_none
+
+        messages = [{
+        "role": "user",
+        "content": [{"text": prompt}]
+        }]      
+        
+        response = self.generate_conversation(self.model_string, system_prompt=sys_prompt_arg, messages=messages, temperature=temperature, top_p=top_p, max_tokens=max_tokens)
+
+
+        response = response.text
+        self._save_cache(sys_prompt_arg + prompt, response)
+        return response


### PR DESCRIPTION
## Overview
This PR adds support for Amazon Bedrock, allowing TextGrad users to leverage a variety of foundation models from AI21 Labs, Anthropic, Cohere, Meta, Mistral AI, Stability AI, and Amazon through a single API.

## Key Changes
- Implemented support for Amazon Bedrock in the `get_engine` function
- Added compatibility for Meta, Anthropic, Cohere, Mistral, and Amazon models
- Introduced a new naming convention for Bedrock models: `bedrock-<model_name_id>` ([here the model id list](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html))

## Usage
To use a Bedrock model, call the `get_engine` function with the Bedrock model name ID prefixed by "bedrock-". For example:

```python
engine = get_engine("bedrock-anthropic.claude-3-sonnet-20240229-v1:0", max_tokens=2048)
```

## Authentication
The PR supports two authentication methods:
1. AWS environment using AWS Roles
2. Environment variables:

- AWS_DEFAULT_REGION (optional)
- AWS_SECRET_ACCESS_KEY
- AWS_ACCESS_KEY_ID
- AWS_SESSION_TOKEN (optional)

## Supported Models
This PR adds support for the following model families:
- Meta
- Anthropic
- Cohere
- Mistral
- Amazon

A complete list of supported model IDs will be added to the documentation.

## Testing
- Tested with various Bedrock models
- Verified authentication methods
- Ensured compatibility with existing TextGrad functionality

## Feedback
I welcome any feedback or suggestions for improvement. Please let me know if any additional changes or clarifications are needed.