### PR TITLE
Ensure that the MANIFEST.in file includes all necessary folders

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include README.md
 include requirements.txt
-recursive-include textgrad *
+recursive-include textgrad *.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.md
+include requirements.txt
+recursive-include textgrad *


### PR DESCRIPTION
# Minor improvement: Add `MANIFEST.in`

The `MANIFEST.in` file is used to include additional files and directories in the source distribution that might not be automatically included by setuptools.

For example, without `MANIFEST.in`, when install `textgrad` via
```sh
pip install git+https://github.com/zou-group/textgrad.git
```
and then run `import textgrad`, the terminal will throw below error:
```python
>>> import textgrad
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/anaconda3/lib/python3.9/site-packages/textgrad/__init__.py", line 20, in <module>
    from .variable import Variable
  File "/opt/anaconda3/lib/python3.9/site-packages/textgrad/variable.py", line 8, in <module>
    from .utils.image_utils import is_valid_url
ModuleNotFoundError: No module named 'textgrad.utils'
```

Therefore, we need to include the `utils/` folder in the `MANIFEST.in` file (in this case, `recursive-include textgrad *`), so that this folder can be packaged and installed correctly.
