### PR TITLE
Support for vLLM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths-ignore:
     - '**.rst'
+    - 'tests/test_vllm.py' # requires vllm to be installed
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ## TextGrad: Automatic ''Differentiation'' via Text
 
-An autograd engine -- for textual gradients! 
+An autograd engine -- for textual gradients!
 
 TextGrad is a powerful framework  building automatic ``differentiation'' via text.
 TextGrad implements backpropagation through text feedback provided by LLMs, strongly building on the gradient metaphor
@@ -30,7 +30,7 @@ This API is similar to the Pytorch API, making it simple to adapt to your usecas
 ![Analogy with Torch](assets/analogy.png)
 
 ## QuickStart
-If you know PyTorch, you know 80% of TextGrad. 
+If you know PyTorch, you know 80% of TextGrad.
 Let's walk through the key components with a simple example. Say we want to use GPT-4o to solve a simple
 reasoning problem.
 
@@ -47,14 +47,14 @@ question_string = ("If it takes 1 hour to dry 25 shirts under the sun, "
                    "how long will it take to dry 30 shirts under the sun? "
                    "Reason step by step")
 
-question = tg.Variable(question_string, 
-                       role_description="question to the LLM", 
+question = tg.Variable(question_string,
+                       role_description="question to the LLM",
                        requires_grad=False)
 
 answer = model(question)
 ```
 
-> :warning: **answer: To determine how long it will take to dry 30 shirts under the sun,** 
+> :warning: **answer: To determine how long it will take to dry 30 shirts under the sun,**
 > **we can use a proportional relationship based on the given information.**
 > **Here’s the step-by-step reasoning: [.....]**
 > **So, it will take 1.2 hours (or 1 hour and 12 minutes) to dry 30 shirts under the sun.**
@@ -66,26 +66,26 @@ As you can see, **the model's answer is incorrect.** We can optimize the answer 
 
 answer.set_role_description("concise and accurate answer to the question")
 
-# Step 2: Define the loss function and the optimizer, just like in PyTorch! 
-# Here, we don't have SGD, but we have TGD (Textual Gradient Descent) 
-# that works with "textual gradients". 
+# Step 2: Define the loss function and the optimizer, just like in PyTorch!
+# Here, we don't have SGD, but we have TGD (Textual Gradient Descent)
+# that works with "textual gradients".
 optimizer = tg.TGD(parameters=[answer])
-evaluation_instruction = (f"Here's a question: {question_string}. " 
+evaluation_instruction = (f"Here's a question: {question_string}. "
                            "Evaluate any given answer to this question, "
                            "be smart, logical, and very critical. "
                            "Just provide concise feedback.")
-                            
 
-# TextLoss is a natural-language specified loss function that describes 
+
+# TextLoss is a natural-language specified loss function that describes
 # how we want to evaluate the reasoning.
 loss_fn = tg.TextLoss(evaluation_instruction)
 ```
-> :brain: **loss: [...] Your step-by-step reasoning is clear and logical,** 
+> :brain: **loss: [...] Your step-by-step reasoning is clear and logical,**
 > **but it contains a critical flaw in the assumption that drying time is**
 > **directly proportional to the number of shirts. [...]**
 
 ```python
-# Step 3: Do the loss computation, backward pass, and update the punchline. 
+# Step 3: Do the loss computation, backward pass, and update the punchline.
 # Exact same syntax as PyTorch!
 loss = loss_fn(answer)
 loss.backward()
@@ -93,7 +93,7 @@ optimizer.step()
 answer
 ```
 
-> :white_check_mark: **answer: It will still take 1 hour to dry 30 shirts under the sun,** 
+> :white_check_mark: **answer: It will still take 1 hour to dry 30 shirts under the sun,**
 > **assuming they are all laid out properly to receive equal sunlight.**
 
 
@@ -101,7 +101,7 @@ answer
 
 We have many more examples around how TextGrad can optimize all kinds of variables -- code, solutions to problems, molecules, prompts, and all that!
 
-### Tutorials 
+### Tutorials
 
 We have prepared a couple of tutorials to get you started with TextGrad. The order of this
 tutorial is what we would recommend to follow for a beginner. You can run them directly in Google Colab by clicking on the links below (but
@@ -141,6 +141,12 @@ conda install -c conda-forge textgrad
 
 ```sh
 pip install git+https://github.com/zou-group/textgrad.git
+```
+
+**Installing textgrad with vllm**:
+
+```sh
+pip3 install textgrad[vllm]
 ```
 
 See [here](https://pip.pypa.io/en/stable/cli/pip_install/) for more details on various methods of pip installation.
@@ -191,16 +197,16 @@ print(solution.value)
 Output:
 > To solve the equation 3x^2 - 7x + 2 = 0, we use the quadratic formula:
 > x = (-b ± √(b^2 - 4ac)) / 2a
-> 
+>
 > Given:
 > a = 3, b = -7, c = 2
-> 
+>
 > Substitute the values into the formula:
 > x = (7 ± √((-7)^2 - 4(3)(2))) / 6
 > x = (7 ± √(49 - 24)) / 6
 > x = (7 ± √25) / 6
 > x = (7 ± 5) / 6
-> 
+>
 > The solutions are:
 > x1 = (7 + 5) / 6 = 12 / 6 = 2
 > x2 = (7 - 5) / 6 = 2 / 6 = 1/3
@@ -271,10 +277,10 @@ New prediction:
 > 4. Broccoli heads: 3
 > 5. Carrot: 1
 > 6. Yam: 1
-> 
+>
 > Now, let's add up the total number of vegetables:
 > 2 + 2 + 1 + 3 + 1 + 1 = 10
-> 
+>
 > You have a total of 10 vegetables.
 
 ## Resources
@@ -290,10 +296,10 @@ Many existing works greatly inspired this project! Here is a non-exhaustive list
 ### Citation
 ```bibtex
 @article{yuksekgonul2024textgrad,
-      title={TextGrad: Automatic "Differentiation" via Text}, 
+      title={TextGrad: Automatic "Differentiation" via Text},
       author={Mert Yuksekgonul and Federico Bianchi and Joseph Boen and Sheng Liu and Zhi Huang and Carlos Guestrin and James Zou},
       year={2024},
       eprint={2406.07496},
       archivePrefix={arXiv}
 }
-``` 
+```

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     include_package_data=True,
     install_requires=requirements,
     extras_require={
+        "vllm": ["vllm"],
     },
     zip_safe=False,
 )

--- a/tests/test_vllm.py
+++ b/tests/test_vllm.py
@@ -1,0 +1,36 @@
+import os
+import logging
+import pytest
+from typing import Union, List
+
+from textgrad import Variable, BlackboxLLM, TextLoss
+from textgrad.optimizer import TextualGradientDescent
+from textgrad.engine.vllm import ChatVLLM
+
+logging.disable(logging.CRITICAL)
+vllm_engine = ChatVLLM(model_string="mistralai/Mistral-7B-Instruct-v0.3")
+
+def test_import_vllm():
+    assert ChatVLLM
+
+def test_simple_forward_pass_engine():
+    text = Variable("Hello", role_description="A variable")
+    engine = BlackboxLLM(engine=vllm_engine)
+    response = engine(text)
+
+    assert response
+
+def test_primitives():
+    """
+    Test the basic functionality of the Variable class.
+    """
+    x = Variable("A sntence with a typo", role_description="The input sentence", requires_grad=True)
+    system_prompt = Variable("Evaluate the correctness of this sentence", role_description="The system prompt")
+    loss = TextLoss(system_prompt, engine=vllm_engine)
+    optimizer = TextualGradientDescent(parameters=[x], engine=vllm_engine)
+
+    l = loss(x)
+    l.backward(vllm_engine)
+    optimizer.step()
+
+    assert x.value == "A sentence with a typo"

--- a/tests/test_vllm.py
+++ b/tests/test_vllm.py
@@ -8,7 +8,7 @@ from textgrad.optimizer import TextualGradientDescent
 from textgrad.engine.vllm import ChatVLLM
 
 logging.disable(logging.CRITICAL)
-vllm_engine = ChatVLLM(model_string="mistralai/Mistral-7B-Instruct-v0.3")
+vllm_engine = ChatVLLM(model_string="meta-llama/Meta-Llama-3-8B-Instruct")
 
 def test_import_vllm():
     assert ChatVLLM

--- a/textgrad/engine/__init__.py
+++ b/textgrad/engine/__init__.py
@@ -6,6 +6,7 @@ __ENGINE_NAME_SHORTCUTS__ = {
     "sonnet": "claude-3-sonnet-20240229",
     "sonnet-3.5": "claude-3-5-sonnet-20240620",
     "together-llama-3-70b": "together-meta-llama/Llama-3-70b-chat-hf",
+    "vllm-llama-3-8b": "vllm-meta-llama/Meta-Llama-3-8B-Instruct",
 }
 
 # Any better way to do this?
@@ -49,5 +50,9 @@ def get_engine(engine_name: str, **kwargs) -> EngineLM:
     elif engine_name in ["command-r-plus", "command-r", "command", "command-light"]:
         from .cohere import ChatCohere
         return ChatCohere(model_string=engine_name, **kwargs)
+    elif "vllm" in engine_name:
+        from .vllm import ChatVLLM
+        engine_name = engine_name.replace("vllm-", "")
+        return ChatVLLM(model_string=engine_name, **kwargs)
     else:
         raise ValueError(f"Engine {engine_name} not supported")

--- a/textgrad/engine/vllm.py
+++ b/textgrad/engine/vllm.py
@@ -1,0 +1,55 @@
+try:
+    from vllm import LLM, SamplingParams
+except ImportError:
+    raise ImportError("If you'd like to use VLLM models, please install the vllm package by running `pip install vllm` or `pip install textgrad[vllm].")
+
+import os
+import platformdirs
+from .base import EngineLM, CachedEngine
+
+class ChatVLLM(EngineLM, CachedEngine):
+    # Default system prompt for VLLM models
+    DEFAULT_SYSTEM_PROMPT = ""
+
+    def __init__(self, model_string="meta-llama/Meta-Llama-3-8B-Instruct", system_prompt=DEFAULT_SYSTEM_PROMPT):
+        root = platformdirs.user_cache_dir("textgrad")
+        cache_path = os.path.join(root, f"cache_vllm_{model_string}.db")
+        super().__init__(cache_path=cache_path)
+
+        self.model_string = model_string
+        self.system_prompt = system_prompt
+        self.client = LLM(self.model_string)
+        self.tokenizer = self.client.get_tokenizer()
+
+    def generate(self, prompt, system_prompt=None, temperature=0, max_tokens=2000, top_p=0.99):
+        sys_prompt_arg = system_prompt if system_prompt else self.system_prompt
+        cache_or_none = self._check_cache(sys_prompt_arg + prompt)
+        if cache_or_none is not None:
+            return cache_or_none
+
+        # The chat template ignores the system prompt;
+        conversation = []
+        if sys_prompt_arg:
+            conversation = [{"role": "system", "content": sys_prompt_arg}]
+
+        conversation += [
+            {"role": "user", "content": prompt}
+        ]
+        chat_str = self.tokenizer.apply_chat_template(conversation, tokenize=False)
+
+        sampling_params = SamplingParams(
+            temperature=temperature,
+            max_tokens=max_tokens,
+            top_p=top_p,
+            n=1
+        )
+
+        response = self.client.generate([chat_str], sampling_params)
+        response = response[0].outputs[0].text
+
+        self._save_cache(sys_prompt_arg + prompt, response)
+
+        return response
+
+    def __call__(self, prompt, **kwargs):
+        return self.generate(prompt, **kwargs)


### PR DESCRIPTION
Thanks for creating the library.  I've added support for the vLLM in a new PR since I noticed there was no activity on vLLM PR (#7). 

Includes: 
1. `ChatVLLM` class for vLLM. 
2. Following @mertyg's suggestion in #7, I've added an example from the tutorial. The test passes for meta-llama/Meta-Llama-3-8B-Instruct. I'm not sure how to install vLLM on Github, so I've excluded the test from the workflow (see .github/workflows/build.yml). 
4. To use vLLM, users have to install with `pip install textgrad[vllm]`. 

Happy to make any changes to get this merged into textgrad. 