### PR TITLE
bugfix: provide text to be updated in VARIABLE

### DIFF
--- a/textgrad/autograd/llm_backward_prompts.py
+++ b/textgrad/autograd/llm_backward_prompts.py
@@ -23,7 +23,7 @@ BACKWARD_SYSTEM_PROMPT = (
 # First part of the prompt for the llm backward function
 CONVERSATION_TEMPLATE = (
     "<LM_SYSTEM_PROMPT> {system_prompt} </LM_SYSTEM_PROMPT>\n\n"
-    "<LM_INPUT> {prompt} </LM_INPUT>\n\n"
+    "<VARIABLE> {prompt} </VARIABLE>\n\n"
     "<LM_OUTPUT> {response_value} </LM_OUTPUT>\n\n"
 )
 


### PR DESCRIPTION
The optimizer expects the text to be updated in VARIABLE. It was previously provided in LM_INPUT, which sometimes led to the LLM improving the wrong text.