### PR TITLE
Fix AssertionError for numpy.int64 in Variable Initialization

### DIFF
--- a/textgrad/variable.py
+++ b/textgrad/variable.py
@@ -40,8 +40,8 @@ class Variable:
             raise Exception("If the variable does not require grad, none of its predecessors should require grad."
                             f"In this case, following predecessors require grad: {_predecessor_requires_grad}")
         
-        assert type(value) in [str, bytes, int], "Value must be a string, int, or image (bytes). Got: {}".format(type(value))
-        if isinstance(value, int):
+        assert isinstance(value, (str, bytes, int)) or np.issubdtype(type(value), np.integer), "Value must be a string, int, or image (bytes). Got: {}".format(type(value))
+        if isinstance(value, int) or np.issubdtype(type(value), np.integer):
             value = str(value)
         # We'll currently let "empty variables" slide, but we'll need to handle this better in the future.
         # if value == "" and image_path == "":


### PR DESCRIPTION
_This pull request addresses an issue where an AssertionError is thrown when initializing a Variable with a numpy.int64 type value. The error occurs because the current assertion does not recognize numpy.int64 as a valid integer type._

**Proposed Fix**
This fix updates the assertion to include numpy.int64 as a valid type. This is done by checking for subtypes of int using numpy.issubdtype.
Additionally, the following code was adapted when casting integers to strings.

Here is the updated code:
```python
assert isinstance(value, (str, bytes, int)) or np.issubdtype(type(value), np.integer), "Value must be a string, int, or image (bytes). Got: {}".format(type(value))
if isinstance(value, int) or np.issubdtype(type(value), np.integer):
    value = str(value)
```

**Testing**
- [x] Tested with numpy.int64 values to ensure the assertion no longer fails.