### PR TITLE
Support for Vertex AI

### DIFF
--- a/examples/vertex/vertex_test.py
+++ b/examples/vertex/vertex_test.py
@@ -1,0 +1,18 @@
+import textgrad as tg
+import vertexai
+
+vertexai.init(project="your-project-id")
+
+tg.set_backward_engine("vertex-gemini-1.5-flash-001", override=True)
+
+# Step 1: Get an initial response from an LLM.
+model = tg.BlackboxLLM("vertex-gemini-1.5-flash-001")
+question_string = ("If it takes 1 hour to dry 25 shirts under the sun, "
+                   "how long will it take to dry 30 shirts under the sun? "
+                   "Reason step by step")
+
+question = tg.Variable(question_string,
+                       role_description="question to the LLM",
+                       requires_grad=False)
+
+answer = model(question)

--- a/textgrad/engine/__init__.py
+++ b/textgrad/engine/__init__.py
@@ -45,9 +45,13 @@ def get_engine(engine_name: str, **kwargs) -> EngineLM:
     elif "claude" in engine_name:
         from .anthropic import ChatAnthropic
         return ChatAnthropic(model_string=engine_name, is_multimodal=_check_if_multimodal(engine_name), **kwargs)
-    elif "gemini" in engine_name:
+    elif engine_name.startswith("gemini"):
         from .gemini import ChatGemini
         return ChatGemini(model_string=engine_name, **kwargs)
+    elif engine_name.startswith("vertex-"):
+        engine_name = engine_name.replace("vertex-", "")
+        from .vertexai import ChatVertexAI
+        return ChatVertexAI(model_string=engine_name, **kwargs)
     elif "together" in engine_name:
         from .together import ChatTogether
         engine_name = engine_name.replace("together-", "")

--- a/textgrad/engine/vertexai.py
+++ b/textgrad/engine/vertexai.py
@@ -1,0 +1,71 @@
+try:
+    from google.cloud.aiplatform import initializer
+    from vertexai.generative_models import (GenerativeModel, 
+                                            GenerationConfig,
+                                            Part,
+                                            Content)
+except ImportError:
+    raise ImportError("If you'd like to use Vertex models, please install the google-cloud-aiplatform package by running `pip install google-cloud-aiplatform>=1.38`, and init your environment with vertex.init()")
+
+import os
+import platformdirs
+from tenacity import (
+    retry,
+    stop_after_attempt,
+    wait_random_exponential,
+)
+from .base import EngineLM, CachedEngine
+
+
+class ChatVertexAI(EngineLM, CachedEngine):
+    SYSTEM_PROMPT = "You are a helpful, creative, and smart assistant."
+
+    def __init__(
+        self,
+        model_string="vertex-gemini-1.5-flash-001",
+        system_prompt=SYSTEM_PROMPT,
+    ):
+
+        root = platformdirs.user_cache_dir("textgrad")
+        cache_path = os.path.join(root, f"cache_vertexai_{model_string}.db")
+        super().__init__(cache_path=cache_path)
+    
+        if not initializer.global_config._project:
+            raise ValueError("Please init with vertex.init() if you'd like to use Vertex models.")
+        
+        self.model_string = model_string
+        self.system_prompt = system_prompt
+        assert isinstance(self.system_prompt, str)
+
+    @retry(wait=wait_random_exponential(min=1, max=5), stop=stop_after_attempt(5))
+    def __call__(self, prompt, **kwargs):
+        return self.generate(prompt, **kwargs)
+
+    @retry(wait=wait_random_exponential(min=1, max=5), stop=stop_after_attempt(5))
+    def generate(
+        self, prompt, system_prompt=None, temperature=0, max_tokens=2000, top_p=0.99
+    ):
+
+        sys_prompt_arg = system_prompt if system_prompt else self.system_prompt
+        cache_or_none = self._check_cache(sys_prompt_arg + prompt)
+        if cache_or_none is not None:
+            return cache_or_none
+        
+        client = GenerativeModel(self.model_string, system_instruction=sys_prompt_arg)
+
+        messages = Content(role="user",
+                           parts=[Part.from_text(prompt)])
+        
+        generation_config =  GenerationConfig(max_output_tokens=max_tokens,
+                                                temperature=temperature,
+                                                top_p=top_p,
+                                                candidate_count=1)
+        
+        
+        response = client.generate_content(messages, 
+                                           generation_config=generation_config)
+
+
+        response = response.text
+        self._save_cache(sys_prompt_arg + prompt, response)
+        return response


### PR DESCRIPTION
Support for Vertex AI (#37). It would be nice if someone also with Gemini API key could quickly review whether the change works.

# Usage

When using models from Vertex, always start with "vertex-" prefix. For example "gemini-1.5-flash-preview-0514" should be  defined as "vertex-gemini-1.5-flash-preview-0514"

As you would with any Vertex AI API, first initialize with your project (and optionally with location etc.):

`vertexai.init(project="your-project-id")`

