### PR TITLE
Add gpt-4o-mini to MultiModel Engines.

### DIFF
--- a/examples/notebooks/Tutorial-MultiModal.ipynb
+++ b/examples/notebooks/Tutorial-MultiModal.ipynb
@@ -61,7 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tg.set_backward_engine(\"gpt-4o\")"
+    "tg.set_backward_engine(\"gpt-4o-mini\")"
    ]
   },
   {
@@ -138,7 +138,7 @@
    ],
    "source": [
     "question_variable = tg.Variable(\"What do you see in this image?\", role_description=\"question\", requires_grad=False)\n",
-    "response = MultimodalLLMCall(\"gpt-4o\")([image_variable, question_variable])\n",
+    "response = MultimodalLLMCall(\"gpt-4o-mini\")([image_variable, question_variable])\n",
     "response"
    ]
   },

--- a/textgrad/engine/__init__.py
+++ b/textgrad/engine/__init__.py
@@ -12,6 +12,7 @@ __ENGINE_NAME_SHORTCUTS__ = {
 # Any better way to do this?
 __MULTIMODAL_ENGINES__ = ["gpt-4-turbo",
                           "gpt-4o",
+                          "gpt-4o-mini",
                           "claude-3-5-sonnet-20240620",
                           "claude-3-opus-20240229",
                           "claude-3-sonnet-20240229",


### PR DESCRIPTION
Add gpt-4o-mini to MultiModel Engines

Introduces support for gpt-4o-mini, a cost-efficient small multimodal model.
Resolves issue #123 