### PR TITLE
feat: upgrade litellm to better support bedrocks and llama 3.2 model

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ datasets>=2.14.6
 diskcache>=5.6.3
 graphviz>=0.20.3
 gdown>=5.2.0
-litellm==1.44.22
+litellm==1.49.5
 pillow
 httpx


### PR DESCRIPTION
This PR is to update litellm engine to 1.49.5 for better supporting llama 3.2 model in bedrocks.

cc @vinid.