### PR TITLE
Fix incorrect type hint in experimental engine

### DIFF
--- a/textgrad/engine_experimental/base.py
+++ b/textgrad/engine_experimental/base.py
@@ -78,7 +78,7 @@ class EngineLM(ABC):
     def _generate_from_single_prompt(self, prompt, system_prompt=None, **kwargs) -> str:
         pass
 
-    def generate(self, content, system_prompt: Union[str | List[Union[str, bytes]]] = None, **kwargs):
+    def generate(self, content, system_prompt: Union[str, List[Union[str, bytes]]] = None, **kwargs):
         sys_prompt_arg = system_prompt if system_prompt else self.system_prompt
 
         if isinstance(content, str):


### PR DESCRIPTION
This type hint was causing our Python 3.9 test suit to throw some type errors.

```python
    def generate(self, content, system_prompt: Union[str | List[Union[str, bytes]]] = None, **kwargs):
E   TypeError: unsupported operand type(s) for |: 'type' and '_GenericAlias'
```
The typehint wasn't correct on any Python version, but Python 3.9 doesn't support `|` between types. The new hint is _more_ correct, at least. Not sure why it can take a list[bytes] though.