### PR TITLE
Fix NumPy scalar handling in Tutorial-Prompt-Optimization.ipynb

### DIFF
--- a/examples/notebooks/Tutorial-Prompt-Optimization.ipynb
+++ b/examples/notebooks/Tutorial-Prompt-Optimization.ipynb
@@ -90,6 +90,28 @@
    ]
   },
   {
+    "cell_type": "code",
+    "source": [
+      "def safe_convert_to_variable(value, **kwargs):\n",
+      "    \"\"\"\n",
+      "    Safely convert a value (including numpy scalars) to a TextGrad Variable.\n",
+      "    \"\"\"\n",
+      "    if isinstance(value, (np.generic, np.ndarray)):\n",
+      "        value = value.item()\n",
+      "\n",
+      "    if not isinstance(value, (str, int, bytes)):\n",
+      "        raise TypeError(f\"Unsupported type for Variable: {type(value)}\")\n",
+      "\n",
+      "    return tg.Variable(value, **kwargs)"
+    ],
+    "metadata": {
+      "id": "Vdirus0fjndu"
+    },
+    "id": "Vdirus0fjndu",
+    "execution_count": null,
+    "outputs": []
+  },
+  {
    "cell_type": "code",
    "execution_count": 9,
    "id": "649e06aef34d0990",
@@ -105,7 +127,7 @@
     "    \"\"\"\n",
     "    x, y = item\n",
     "    x = tg.Variable(x, requires_grad=False, role_description=\"query to the language model\")\n",
-    "    y = tg.Variable(y, requires_grad=False, role_description=\"correct answer for the query\")\n",
+    "    y = safe_convert_to_variable(y, requires_grad=False, role_description=\"correct answer for the query\")\n",
     "    response = model(x)\n",
     "    try:\n",
     "        eval_output_variable = eval_fn(inputs=dict(prediction=response, ground_truth_answer=y))\n",
@@ -498,7 +520,7 @@
     "        losses = []\n",
     "        for (x, y) in zip(batch_x, batch_y):\n",
     "            x = tg.Variable(x, requires_grad=False, role_description=\"query to the language model\")\n",
-    "            y = tg.Variable(y, requires_grad=False, role_description=\"correct answer for the query\")\n",
+    "            y = safe_convert_to_variable(y, requires_grad=False, role_description=\"correct answer for the query\")\n",
     "            response = model(x)\n",
     "            try:\n",
     "                eval_output_variable = eval_fn(inputs=dict(prediction=response, ground_truth_answer=y))\n",


### PR DESCRIPTION
fix: safely handle numpy scalar and array types when creating tg.Variable

TextGrad's Variable constructor expects inputs of type str, int, or bytes. However, datasets often return numpy scalar types (e.g., np.int64) or single-element numpy arrays that cause assertion errors like:

    AssertionError: Value must be a string, int, or image (bytes). Got: <class 'numpy.int64'>

Added a helper function `safe_convert_to_variable` that checks if the input is a numpy scalar or array and converts it to a native Python type using `.item()`. It then verifies the type before wrapping the value into a tg.Variable.

Also, replaced the direct tg.Variable calls with `safe_convert_to_variable` in evaluation and training loops to ensure robust and error-free variable creation from dataset samples.